### PR TITLE
Add optional wrapper for gpu-2404 interface

### DIFF
--- a/bin/gpu-2404-optional-wrapper
+++ b/bin/gpu-2404-optional-wrapper
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if ! snapctl is-connected gpu-2404
+then
+  echo "WARNING: the gpu-2404 interface isn't connected."
+  echo "  You may want to install and connect a graphics userspace provider."
+  echo ""
+  echo "The default provider is mesa-2404, you can install it and connect by issuing:"
+  echo "  sudo snap install mesa-2404"
+  echo "  sudo snap connect ${SNAP_INSTANCE_NAME}:gpu-2404 mesa-2404"
+  echo ""
+  echo "See https://mir-server.io/docs/the-gpu-2404-snap-interface for more information."
+  exit 0
+fi
+
+exec "${SNAP}/gpu-2404/bin/gpu-2404-provider-wrapper" "$@"


### PR DESCRIPTION
Add optional wrapper for gpu-2404 that does not fail if the interface isn't connected

This is for use cases they the graphics support is provided can be provided by different mechanisms, such as classic vs core hosts.