### PR TITLE
Compare file lists between this and the original snap

### DIFF
--- a/.github/workflows/refresh-lists.yml
+++ b/.github/workflows/refresh-lists.yml
@@ -44,8 +44,6 @@ jobs:
           echo -n "${{ steps.snap-matrix.outputs.matrix }}" |
             xargs -d' ' -n3 -P`nproc` \
               bash -xc "unsquashfs -cat \$0_\$2.snap snap/\$2.list \
-                | sed 's/\(.so.[0-9]\+\)\([0-9\.]\+\)\?$/\1*/' \
-                | sort -u \
                 > graphics-core/lists/\$0.\$2.list"
 
       - name: Create pull request

--- a/bin/graphics-core22-cleanup
+++ b/bin/graphics-core22-cleanup
@@ -5,29 +5,29 @@ SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
 
 TMP_FOLDER=/tmp/snap-lists
 
-rm -rf $TMP_FOLDER
-mkdir -p $TMP_FOLDER
+rm -rf ${TMP_FOLDER}
+mkdir -p ${TMP_FOLDER}
 
 (
   for provider in "$@"; do
-    snap download --target-directory $TMP_FOLDER/ --basename $provider $provider
+    snap download --target-directory ${TMP_FOLDER}/ --basename ${provider} ${provider}
     # Process the list exactly like the CI script, to allow to compare it
     # with the ones here.
-    unsquashfs -cat $TMP_FOLDER/$provider.snap snap/${CRAFT_TARGET_ARCH}.list \
+    unsquashfs -cat ${TMP_FOLDER}/${provider}.snap snap/${CRAFT_TARGET_ARCH}.list \
              | sed 's/\(.so.[0-9]\+\)\([0-9\.]\+\)\?$/\1*/' \
              | sort -u \
-             > $TMP_FOLDER/original-list.txt
-    sort -u ${SELF}/lists/$provider.${CRAFT_TARGET_ARCH}.list \
-             > $TMP_FOLDER/compare-list.txt
+             > ${TMP_FOLDER}/original-list.txt
+    sort -u ${SELF}/lists/${provider}.${CRAFT_TARGET_ARCH}.list \
+             > ${TMP_FOLDER}/compare-list.txt
     # If the lists are different, cmp will fail and thus the script too.
     # This ensures that if the upstream snap and this one aren't in sync,
     # the build will be aborted
-    cmp $TMP_FOLDER/original-list.txt $TMP_FOLDER/compare-list.txt
-    rm -rf $TMP_FOLDER/*
+    cmp ${TMP_FOLDER}/original-list.txt ${TMP_FOLDER}/compare-list.txt
+    rm -rf ${TMP_FOLDER}/*
   done
 )
 
-rm -rf $TMP_FOLDER
+rm -rf ${TMP_FOLDER}
 
 rm -f $(
   (

--- a/bin/graphics-core22-cleanup
+++ b/bin/graphics-core22-cleanup
@@ -3,6 +3,32 @@ set -euo pipefail
 
 SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
 
+TMP_FOLDER=/tmp/snap-lists
+
+rm -rf $TMP_FOLDER
+mkdir -p $TMP_FOLDER
+
+(
+  for provider in "$@"; do
+    snap download --target-directory $TMP_FOLDER/ --basename $provider $provider
+    # Process the list exactly like the CI script, to allow to compare it
+    # with the ones here.
+    unsquashfs -cat $TMP_FOLDER/$provider.snap snap/${CRAFT_TARGET_ARCH}.list \
+             | sed 's/\(.so.[0-9]\+\)\([0-9\.]\+\)\?$/\1*/' \
+             | sort -u \
+             > $TMP_FOLDER/original-list.txt
+    sort -u ${SELF}/lists/$provider.${CRAFT_TARGET_ARCH}.list \
+             > $TMP_FOLDER/compare-list.txt
+    # If the lists are different, cmp will fail and thus the script too.
+    # This ensures that if the upstream snap and this one aren't in sync,
+    # the build will be aborted
+    cmp $TMP_FOLDER/original-list.txt $TMP_FOLDER/compare-list.txt
+    rm -rf $TMP_FOLDER/*
+  done
+)
+
+rm -rf $TMP_FOLDER
+
 rm -f $(
   (
     for provider in "$@"; do

--- a/bin/graphics-core22-cleanup
+++ b/bin/graphics-core22-cleanup
@@ -19,7 +19,7 @@ TMP_FOLDER=$(mktemp -d)
     # If the lists are different, cmp will fail and thus the script too.
     # This ensures that if the upstream snap and this one aren't in sync,
     # the build will be aborted
-    cmp ${TMP_FOLDER}/original-list.txt ${TMP_FOLDER}/compare-list.txt
+    cmp ${TMP_FOLDER}/original-list.txt ${SELF}/lists/${provider}.${CRAFT_TARGET_ARCH}.list
     rm -rf ${TMP_FOLDER}/*
   done
 )

--- a/bin/graphics-core22-cleanup
+++ b/bin/graphics-core22-cleanup
@@ -8,14 +8,8 @@ TMP_FOLDER=$(mktemp -d)
 (
   for provider in "$@"; do
     snap download --target-directory ${TMP_FOLDER}/ --basename ${provider} ${provider}
-    # Process the list exactly like the CI script, to allow to compare it
-    # with the ones here.
     unsquashfs -cat ${TMP_FOLDER}/${provider}.snap snap/${CRAFT_TARGET_ARCH}.list \
-             | sed 's/\(.so.[0-9]\+\)\([0-9\.]\+\)\?$/\1*/' \
-             | sort -u \
              > ${TMP_FOLDER}/original-list.txt
-    sort -u ${SELF}/lists/${provider}.${CRAFT_TARGET_ARCH}.list \
-             > ${TMP_FOLDER}/compare-list.txt
     # If the lists are different, cmp will fail and thus the script too.
     # This ensures that if the upstream snap and this one aren't in sync,
     # the build will be aborted

--- a/bin/graphics-core22-cleanup
+++ b/bin/graphics-core22-cleanup
@@ -3,10 +3,7 @@ set -euo pipefail
 
 SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
 
-TMP_FOLDER=/tmp/snap-lists
-
-rm -rf ${TMP_FOLDER}
-mkdir -p ${TMP_FOLDER}
+TMP_FOLDER=$(mktemp -d)
 
 (
   for provider in "$@"; do


### PR DESCRIPTION
The file lists inside this snap must be in sync with the file lists in the original snaps. If that's not the case, that means that the list of files to delete is not reliable, so any snap being built must be aborted.